### PR TITLE
Update hash from sha1 to sha256

### DIFF
--- a/Formula/massren.rb
+++ b/Formula/massren.rb
@@ -3,7 +3,7 @@ require "formula"
 class Massren < Formula
   homepage "https://github.com/laurent22/massren"
   url "https://github.com/laurent22/massren/archive/v1.5.1.tar.gz"
-  sha1 "8c27b3f13aa6d170bd223c5ca21f3394cd7d03e6"
+  sha256 "21a602a29410e30b1b518356d5707b25b22b9d2578aaf0d0d5ab3de9e0ad225d"
   version "1.5.1"
   
   depends_on 'go' => :build


### PR DESCRIPTION
When installing massren via the laurent22/massren tap, there is a warning that SHA1 support is deprecated. This PR fixes that with a SHA256 hash, computed against the download at `https://github.com/laurent22/massren/archive/v1.5.1.tar.gz`.

Output with deprecation warning:

```
○ → brew tap laurent22/massren
○ → brew install massren
==> Installing massren from laurent22/massren
==> Downloading https://github.com/laurent22/massren/archive/v1.5.1.tar.gz
==> Downloading from https://codeload.github.com/laurent22/massren/tar.gz/v1.5.1
######################################################################## 100.0%
Warning: SHA1 support is deprecated and will be removed in a future version.
Please switch this formula to SHA256.
```
